### PR TITLE
feat: input onchange Event hooks

### DIFF
--- a/src/hooks/useInput/useInput.ts
+++ b/src/hooks/useInput/useInput.ts
@@ -1,0 +1,19 @@
+import { ChangeEvent, Dispatch, SetStateAction } from 'react';
+
+const useInput = <T>() => {
+  const inputOnChangeEvent = (
+    e: ChangeEvent<HTMLInputElement>,
+    setValue: Dispatch<SetStateAction<T>>
+  ) => {
+    const { name, value } = e.target;
+
+    setValue((prevValue: T) => ({
+      ...prevValue,
+      [name]: value,
+    }));
+  };
+
+  return [inputOnChangeEvent] as const;
+};
+
+export default useInput;


### PR DESCRIPTION
```jsx
const [inputLogin] = useInput<loginDto>();
```
정의 해서 사용할 수 있습니다.

예제
```jsx
<Input
        {...} // input props
        onChange={(e) => inputLogin(e, setLoginObj)}
        name="userId"
      />
```
사용할 땐 꼭 name을 dto에 맞게 사용해주세요.
```ts
setValue((prevValue: T) => ({
      ...prevValue,
      [name]: value,
    }));
```
이렇기 때문에...
